### PR TITLE
chore: reducing maximum number of workers for jest test runs

### DIFF
--- a/src/util/jest.util.ts
+++ b/src/util/jest.util.ts
@@ -37,7 +37,7 @@ export async function runJest (ci = false, integration = false): Promise<void> {
   const env = {}
 
   if (ci) {
-    args.push('--ci', '--coverage', '--maxWorkers=7')
+    args.push('--ci', '--coverage', '--maxWorkers=2')
   }
 
   // Running all tests - will use `--silent` to suppress console-logs, will also set process.env.JEST_SILENT=1


### PR DESCRIPTION
Since we will be forced to reduce our capacity at Circle CI from 8 core cpus to dual core cpus 
 we also need to reduce the maximum number of workers spawned for jest test runs.